### PR TITLE
ThinReports::Report::Internal#load_layoutで@default_layoutを設定する

### DIFF
--- a/lib/thinreports/report/internal.rb
+++ b/lib/thinreports/report/internal.rb
@@ -68,17 +68,19 @@ module ThinReports
         @finalized
       end
       
-      def load_layout(layout)
-        return @default_layout if layout.nil?
+      def load_layout(id_or_filename)
+        return @default_layout if id_or_filename.nil?
         
-        case layout
+        layout = case id_or_filename
         when Symbol
-          layout_registry[layout]
+          layout_registry[id_or_filename]
         when String
-          prepare_layout(layout)
+          prepare_layout(id_or_filename)
         else
           raise ArgumentError, 'Invalid argument for layout.'
         end
+        @default_layout = layout unless @default_layout
+        layout
       end
       
     private

--- a/test/unit/report/test_internal.rb
+++ b/test/unit/report/test_internal.rb
@@ -230,6 +230,14 @@ class ThinReports::Report::TestInternal < MiniTest::Unit::TestCase
     assert_nil internal.load_layout(:unknown)
   end
   
+  def test_load_layout_should_set_default_layout_when_default_layout_is_nil
+    internal = Report::Internal.new(report, {})
+    internal.load_layout(sample_layout1)
+
+    assert_equal internal.default_layout.filename,
+                 sample_layout1
+  end
+
   def test_load_layout_should_raise_error_when_invalid_value_set
     internal = Report::Internal.new(report, {})
 


### PR DESCRIPTION
`ThinReports::Report::Internal#load_layout`で、`@default_layout`が`nil`の場合は`@default_layout`を設定することを提案します。

動機はですが、レイアウトの設定の仕方で、PDF文書のプロパティのタイトルが設定されない場合があるからです。

以下のコードでは設定されます。

``` ruby
ThinReports::Report.generate do |report|
  report.use_layout: 'sample.tlf'
  report.start_new_page
end
```

しかしながら、以下のコードでは設定されません。

``` ruby
ThinReports::Report.generate do |report|
  report.start_new_page(layout: 'sample.tlf')
end
```

`ThinReports::Report::Base#use_layout`では、`ThinReports::Report::Internal#register_layout`を呼び出し、そこで、`@default_layout`を設定してますが、`ThinReports::Report::Base#start_new_page`では、`ThinReports::Report::Internal#load_layout`を呼び出していますが、`@default_layout`を設定していません。そのため、PDF生成のオブジェクトを生成する時（`ThinReports::Generator::PDF#initialize`）、

``` ruby
title = default_layout ? default_layout.format.report_title : nil

@pdf = Document.new(options, :Title => title)
```

となっており、`@default_layout`を設定されていない場合は、`Title`が`nil`となるため、文書のプロパティのタイトルが設定されません。

最初に`use_layout`を使わなくても、使う場合と同じように動作するほうがいいと考え、このPRを提案します。
