### PR TITLE
Remove unused instance variables

### DIFF
--- a/lib/thinreports/report/base.rb
+++ b/lib/thinreports/report/base.rb
@@ -87,9 +87,6 @@ module Thinreports
       def initialize(options = {})
         @internal = Report::Internal.new(self, options)
         @start_page_number = 1
-
-        @page_create_handler = nil
-        @generate_handler = nil
       end
 
       # @yield [page]


### PR DESCRIPTION
Since they seem not to be used in the Report::Base now, I removed them :fork_and_knife:  