### PR TITLE
Deprecate option for convert_palleted_transparency_png 

### DIFF
--- a/lib/thinreports/config.rb
+++ b/lib/thinreports/config.rb
@@ -43,7 +43,9 @@ module Thinreports
     #   config.convert_palleted_transparency_png = true
     #   config.convert_palleted_transparency_png = false # default
     # @see https://github.com/thinreports/thinreports-generator/pull/32
+    # @deprecated This is deprecated and will be removed in thinreports-generator 1.0 with no replacement
     def convert_palleted_transparency_png=(enable)
+      warn 'This is deprecated and will be removed in thinreports-generator 1.0 with no replacement.' if enable
       @convert_palleted_transparency_png = enable
     end
 


### PR DESCRIPTION
This configuration will be removed in thinreports-generator 1.0 with no replacement.

## Why?

 * この機能を実現するための実装がさまざまな問題を引き起こしている
 * Prawn 2.1 has supported a transparency PNG