### PR TITLE
Drop support old format that is generated with Editor v0.7 or lower

### DIFF
--- a/lib/thinreports/layout/version.rb
+++ b/lib/thinreports/layout/version.rb
@@ -4,7 +4,7 @@ module Thinreports
   module Layout
 
     module Version
-      REQUIRED_RULES = ['>= 0.7.7.0', '< 1.0.0']
+      REQUIRED_RULES = ['>= 0.8.0', '< 1.0.0']
 
       # @param [String] version
       # @return [Boolean]


### PR DESCRIPTION
Now, thinreports will be able to load format that generated with Editor v0.8 or higher.