### PR TITLE
update grade prawn to 2.1.0

### DIFF
--- a/lib/thinreports/generator/pdf.rb
+++ b/lib/thinreports/generator/pdf.rb
@@ -1,11 +1,11 @@
 # coding: utf-8
 
 begin
-  gem 'prawn', '1.3.0'
+  gem 'prawn', '2.1.0'
   require 'prawn'
 rescue LoadError
-  puts 'Thinreports requires Prawn = 1.3.0. ' +
-       'Please `gem install prawn -v 1.3.0` and try again.'
+  puts 'Thinreports requires Prawn = 2.1.0. ' +
+       'Please `gem install prawn -v 2.1.0` and try again.'
 end
 
 module Thinreports

--- a/lib/thinreports/generator/pdf/document/graphics/text.rb
+++ b/lib/thinreports/generator/pdf/document/graphics/text.rb
@@ -27,9 +27,9 @@ module Thinreports
         box_attrs = text_box_attrs(x, y, w, h, single: attrs.delete(:single),
                                                overflow: attrs[:overflow])
         # Do not break by word unless :word_wrap is :break_word
-        content = text_without_line_wrap(content) if attrs[:word_wrap] == :none
 
         with_text_styles(attrs) do |built_attrs, font_styles|
+          content = text_without_line_wrap(content) if attrs[:word_wrap] == :none && pdf.font.unicode?
           pdf.formatted_text_box([{ text: content, styles: font_styles }],
             built_attrs.merge(box_attrs))
         end

--- a/thinreports.gemspec
+++ b/thinreports.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep %r{^test/}
   s.require_paths = ['lib']
 
-  s.add_dependency 'prawn', '1.3.0'
+  s.add_dependency 'prawn', '2.1.0'
   s.add_dependency 'chunky_png', '~> 1.3'
 
   s.add_development_dependency 'bundler', ['>= 1.0.0']


### PR DESCRIPTION
when use prawn 1.3.0, many png files are not supported by this version.
so I want to upgrade prawn 2.1.0

but I can't generate some text, and fix this problem.
#34 uses this issue,but I read prawn code and changing with difference ways.

lib/prawn/text/formatted/line_wrap.rb

``` ruby

177          def set_soft_hyphen_and_zero_width_space
178            # this is done once per fragment, after the font settings for the fragment are applied --
179            #   it could actually be skipped if the font hasn't changed
180            font = @document.font
181            @soft_hyphen = font.normalize_encoding(Prawn::Text::SHY)
182            @zero_width_space = font.unicode? ? Prawn::Text::ZWSP : ""
183          end

```

When using non-unicode font, prawn don't not support with using Parwn::Text::ZWSP charset.
 I change your code with checking font type inside block.

thank you.
