### PR TITLE
Fix a caller of #finalized!

### DIFF
--- a/lib/thinreports/core/shape/list/page.rb
+++ b/lib/thinreports/core/shape/list/page.rb
@@ -87,7 +87,7 @@ module Thinreports
               internal.rows.each do |row|
                 new_list.internal.rows << row.copy(new_list)
               end
-              new_list.finalized!
+              new_list.internal.finalized!
             end
 
             if internal.format.has_header?


### PR DESCRIPTION
`#finalized!` is a method of `Thinreports::Core::Shape::List::PageState`.

Sorry for lack of reproducing test.