### PR TITLE
Prawn::Errors::UnknownFont error occured: "is not a known font"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## master
+
+Bug Fixes:
+
+ * Fixed: Prawn::Errors::UnknownFont error occured: "is not a known font" #89
+
 ## 0.10.1
 
 Bug Fixes:

--- a/lib/thinreports/generator/pdf/document/font.rb
+++ b/lib/thinreports/generator/pdf/document/font.rb
@@ -7,10 +7,10 @@ module Thinreports
         FONT_STORE = Thinreports.root.join('fonts')
 
         BUILTIN_FONTS = {
-          'IPAMincho'  => { normal: FONT_STORE.join('ipam.ttf').to_s },
-          'IPAPMincho' => { normal: FONT_STORE.join('ipamp.ttf').to_s },
-          'IPAGothic'  => { normal: FONT_STORE.join('ipag.ttf').to_s },
-          'IPAPGothic' => { normal: FONT_STORE.join('ipagp.ttf').to_s }
+          'IPAMincho'  => FONT_STORE.join('ipam.ttf').to_s,
+          'IPAPMincho' => FONT_STORE.join('ipamp.ttf').to_s,
+          'IPAGothic'  => FONT_STORE.join('ipag.ttf').to_s,
+          'IPAPGothic' => FONT_STORE.join('ipagp.ttf').to_s
         }.freeze
 
         DEFAULT_FALLBACK_FONTS = %w[IPAMincho].freeze
@@ -22,7 +22,9 @@ module Thinreports
 
         def setup_fonts
           # Install built-in fonts.
-          pdf.font_families.update(BUILTIN_FONTS)
+          BUILTIN_FONTS.each do |font_name, font_path|
+            install_font(font_name, font_path)
+          end
 
           # Create aliases from the font list provided by Prawn.
           PRAWN_BUINTIN_FONT_ALIASES.each do |alias_name, name|
@@ -69,11 +71,16 @@ module Thinreports
           pdf.font_families.key?(family) ? family : default_family
         end
 
-        # @param [String] font
-        # @param [Symbol] style
+        # @param [String] font_name
+        # @param [:bold, :italic] font_style
         # @return [Boolean]
-        def font_has_style?(font, style)
-          (f = pdf.font_families[font]) && f.key?(style)
+        def font_has_style?(font_name, font_style)
+          font = pdf.font_families[font_name]
+
+          return false unless font
+          return false unless font.key?(font_style)
+
+          font[font_style] != font[:normal]
         end
       end
     end


### PR DESCRIPTION
## Steps to reproduce

Schema (example.tlf)

```
    :
  "items": [
    {
      "id": "text",
      "type": "text-block",
        :
      "style": {
        "font-family": [
          "Helvetica"
        ],
    }
  ],
    :
```

Code

```ruby
page.item(:text).style(:bold, true).value('aaaaあ')
page.item(:text).style(:italic, true).value('aaaaあ')
```

Error

```
8: from /Users/--/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/prawn-2.2.2/lib/prawn/text/formatted/line_wrap.rb:77:in `apply_font_settings_and_add_fragment_to_line'
7: from /Users/--/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/prawn-2.2.2/lib/prawn/text/formatted/arranger.rb:166:in `apply_font_settings'
6: from /Users/--/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/pdf-core-0.7.0/lib/pdf/core/text.rb:214:in `character_spacing'
5: from /Users/--/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/prawn-2.2.2/lib/prawn/text/formatted/arranger.rb:169:in `block in apply_font_settings'
4: from /Users/--/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/prawn-2.2.2/lib/prawn/font.rb:57:in `font'
3: from /Users/--/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/prawn-2.2.2/lib/prawn/font.rb:253:in `find_font'
2: from /Users/--/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/prawn-2.2.2/lib/prawn/font.rb:301:in `load'
1: from /Users/--/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/prawn-2.2.2/lib/prawn/font.rb:301:in `new'
/Users/--/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/prawn-2.2.2/lib/prawn/font/afm.rb:53:in `initialize':  is not a known font. (Prawn::Errors::UnknownFont)
```

## Environments

- Thinreports Generator 0.10.1
- Thinreports Editor 0.10.0
- Ruby 2.5.0

## Cause

1. Helvetica (AFM) does not support "あ" character
2. Prawn will apply fallback font
3. IPAMincho has applied as fallback font
4. IPAMincho supports "あ" character, but does not have .ttf for bold style
5. Prawn can't find font, and raises `Prawn::Errors::UnknownFont`
