### PR TITLE
Fix corner-radius of rect is not applied correctly

### DIFF
--- a/examples/graphics/graphics.rb
+++ b/examples/graphics/graphics.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+example :graphics, 'Basic graphics' do |t|
+  report = Thinreports::Report.new layout: t.layout_filename
+  report.start_new_page
+  report.generate filename: t.output_filename
+end

--- a/examples/graphics/graphics.tlf
+++ b/examples/graphics/graphics.tlf
@@ -1,0 +1,309 @@
+{
+  "version": "0.10.0",
+  "items": [
+    {
+      "id": "",
+      "type": "rect",
+      "display": true,
+      "description": "",
+      "x": 20,
+      "y": 59,
+      "width": 120.1,
+      "height": 62,
+      "style": {
+        "border-color": "#000000",
+        "border-width": 1,
+        "border-style": "solid",
+        "fill-color": "#FFFFFF"
+      },
+      "border-radius": 0
+    },
+    {
+      "id": "",
+      "type": "rect",
+      "display": true,
+      "description": "",
+      "x": 155,
+      "y": 59,
+      "width": 120.1,
+      "height": 62,
+      "style": {
+        "border-color": "#000000",
+        "border-width": 1,
+        "border-style": "solid",
+        "fill-color": "#FFFFFF"
+      },
+      "border-radius": 10
+    },
+    {
+      "id": "",
+      "type": "text",
+      "display": true,
+      "description": "",
+      "x": 20,
+      "y": 20,
+      "width": 103.1,
+      "height": 21,
+      "style": {
+        "font-family": [
+          "Helvetica"
+        ],
+        "font-size": 18,
+        "color": "#000000",
+        "text-align": "left",
+        "vertical-align": "top",
+        "line-height": "",
+        "line-height-ratio": "",
+        "letter-spacing": "",
+        "font-style": []
+      },
+      "texts": [
+        "Rect (static)"
+      ]
+    },
+    {
+      "id": "",
+      "type": "rect",
+      "display": true,
+      "description": "",
+      "x": 290,
+      "y": 59,
+      "width": 120.1,
+      "height": 62,
+      "style": {
+        "border-color": "#000000",
+        "border-width": 1,
+        "border-style": "dashed",
+        "fill-color": "#FFFFFF"
+      },
+      "border-radius": 10
+    },
+    {
+      "id": "",
+      "type": "rect",
+      "display": true,
+      "description": "",
+      "x": 425,
+      "y": 59,
+      "width": 120.1,
+      "height": 62,
+      "style": {
+        "border-color": "#000000",
+        "border-width": 1,
+        "border-style": "dotted",
+        "fill-color": "#FFFFFF"
+      },
+      "border-radius": 10
+    },
+    {
+      "id": "",
+      "type": "rect",
+      "display": true,
+      "description": "",
+      "x": 20,
+      "y": 140,
+      "width": 120.1,
+      "height": 62,
+      "style": {
+        "border-color": "#ff0000",
+        "border-width": 1,
+        "border-style": "solid",
+        "fill-color": "#FFFFFF"
+      },
+      "border-radius": 0
+    },
+    {
+      "id": "",
+      "type": "rect",
+      "display": true,
+      "description": "",
+      "x": 155,
+      "y": 140,
+      "width": 120.1,
+      "height": 62,
+      "style": {
+        "border-color": "none",
+        "border-width": 1,
+        "border-style": "solid",
+        "fill-color": "#ff0000"
+      },
+      "border-radius": 0
+    },
+    {
+      "id": "",
+      "type": "rect",
+      "display": true,
+      "description": "",
+      "x": 250,
+      "y": 140,
+      "width": 97.1,
+      "height": 43,
+      "style": {
+        "border-color": "#0070c0",
+        "border-width": 1,
+        "border-style": "solid",
+        "fill-color": "none"
+      },
+      "border-radius": 0
+    },
+    {
+      "id": "rect1",
+      "type": "rect",
+      "display": true,
+      "description": "",
+      "x": 20,
+      "y": 265,
+      "width": 120.1,
+      "height": 62,
+      "style": {
+        "border-color": "#000000",
+        "border-width": 1,
+        "border-style": "solid",
+        "fill-color": "#FFFFFF"
+      },
+      "border-radius": 0
+    },
+    {
+      "id": "rect2",
+      "type": "rect",
+      "display": true,
+      "description": "",
+      "x": 155,
+      "y": 265,
+      "width": 120.1,
+      "height": 62,
+      "style": {
+        "border-color": "#000000",
+        "border-width": 1,
+        "border-style": "solid",
+        "fill-color": "#FFFFFF"
+      },
+      "border-radius": 10
+    },
+    {
+      "id": "rect3",
+      "type": "rect",
+      "display": true,
+      "description": "",
+      "x": 290,
+      "y": 265,
+      "width": 120.1,
+      "height": 62,
+      "style": {
+        "border-color": "#000000",
+        "border-width": 1,
+        "border-style": "dashed",
+        "fill-color": "#FFFFFF"
+      },
+      "border-radius": 10
+    },
+    {
+      "id": "rect4",
+      "type": "rect",
+      "display": true,
+      "description": "",
+      "x": 425,
+      "y": 265,
+      "width": 120.1,
+      "height": 62,
+      "style": {
+        "border-color": "#000000",
+        "border-width": 1,
+        "border-style": "dotted",
+        "fill-color": "#FFFFFF"
+      },
+      "border-radius": 10
+    },
+    {
+      "id": "rect5",
+      "type": "rect",
+      "display": true,
+      "description": "",
+      "x": 20,
+      "y": 346,
+      "width": 120.1,
+      "height": 62,
+      "style": {
+        "border-color": "#ff0000",
+        "border-width": 1,
+        "border-style": "solid",
+        "fill-color": "#FFFFFF"
+      },
+      "border-radius": 0
+    },
+    {
+      "id": "rect6",
+      "type": "rect",
+      "display": true,
+      "description": "",
+      "x": 155,
+      "y": 346,
+      "width": 120.1,
+      "height": 62,
+      "style": {
+        "border-color": "none",
+        "border-width": 1,
+        "border-style": "solid",
+        "fill-color": "#ff0000"
+      },
+      "border-radius": 0
+    },
+    {
+      "id": "rect7",
+      "type": "rect",
+      "display": true,
+      "description": "",
+      "x": 250,
+      "y": 346,
+      "width": 97.1,
+      "height": 43,
+      "style": {
+        "border-color": "#0070c0",
+        "border-width": 1,
+        "border-style": "solid",
+        "fill-color": "none"
+      },
+      "border-radius": 0
+    },
+    {
+      "id": "",
+      "type": "text",
+      "display": true,
+      "description": "",
+      "x": 20,
+      "y": 225,
+      "width": 125.1,
+      "height": 21,
+      "style": {
+        "font-family": [
+          "Helvetica"
+        ],
+        "font-size": 18,
+        "color": "#000000",
+        "text-align": "left",
+        "vertical-align": "top",
+        "line-height": "",
+        "line-height-ratio": "",
+        "letter-spacing": "",
+        "font-style": []
+      },
+      "texts": [
+        "Rect (dynamic)"
+      ]
+    }
+  ],
+  "state": {
+    "layout-guides": []
+  },
+  "title": "",
+  "report": {
+    "paper-type": "A4",
+    "orientation": "portrait",
+    "margin": [
+      20,
+      20,
+      20,
+      20
+    ]
+  }
+}

--- a/lib/thinreports/generator/pdf/document/draw_shape.rb
+++ b/lib/thinreports/generator/pdf/document/draw_shape.rb
@@ -75,7 +75,7 @@ module Thinreports
         def draw_shape_rect(shape)
           x, y, w, h = shape.format.attributes.values_at('x', 'y', 'width', 'height')
           rect_attributes = build_graphic_attributes(shape.style.finalized_styles) do |attrs|
-            attrs[:radius] = shape.format.attributes['rx']
+            attrs[:radius] = shape.format.attributes['border-radius']
           end
           rect(x, y, w, h, rect_attributes)
         end

--- a/lib/thinreports/generator/pdf/document/draw_template_items.rb
+++ b/lib/thinreports/generator/pdf/document/draw_template_items.rb
@@ -25,7 +25,7 @@ module Thinreports
         def draw_rect(item_attributes)
           x, y, w, h = item_attributes.values_at('x', 'y', 'width', 'height')
           graphic_attributes = build_graphic_attributes(item_attributes['style']) do |attrs|
-            attrs[:radius] = item_attributes['rx']
+            attrs[:radius] = item_attributes['border-radius']
           end
 
           rect(x, y, w, h, graphic_attributes)

--- a/lib/thinreports/layout/legacy_schema.rb
+++ b/lib/thinreports/layout/legacy_schema.rb
@@ -104,6 +104,7 @@ module Thinreports
           'width' => attributes['width'].to_f,
           'height' => attributes['height'].to_f,
           'display' => display(attributes['x-display']),
+          'border-radius' => attributes['rx'].to_i,
           'style' => {
             'border-width' => attributes['stroke-width'].to_f,
             'border-color' => attributes['stroke'],

--- a/test/unit/layout/test_legacy_schema.rb
+++ b/test/unit/layout/test_legacy_schema.rb
@@ -104,7 +104,8 @@ class Thinreports::Layout::TestLegacySchema < Minitest::Test
       'stroke-width' => '2.5',
       'stroke' => '#ff0000',
       'x-stroke-type' => 'dotted',
-      'fill' => 'red'
+      'fill' => 'red',
+      'rx' => '2'
     }
     assert_equal(
       {
@@ -115,6 +116,7 @@ class Thinreports::Layout::TestLegacySchema < Minitest::Test
         'width' => 300.1,
         'height' => 400.1,
         'display' => false,
+        'border-radius' => 2,
         'style' => {
           'border-width' => 2.5,
           'border-color' => '#ff0000',


### PR DESCRIPTION
## Problem

The corner radius of Rect is not applied.

## Steps to reproduce

1. revert https://github.com/thinreports/thinreports-generator/commit/5af1d127acef1634a5f8f00991080743258958ec
2. `rake examples:graphics`

## Expected Behavior

Specified corner-radius is applied to the rect correctly.

## Actual Behavior

Specified corner-radius never applied to the rect.