### PR TITLE
Support Pathname layout option on Thinreports::Report

### DIFF
--- a/lib/thinreports/report/internal.rb
+++ b/lib/thinreports/report/internal.rb
@@ -96,6 +96,8 @@ module Thinreports
       end
 
       def init_layout(filename, id = nil)
+        filename = filename.to_path if filename.is_a?(Pathname)
+
         Thinreports::Layout.new(filename, id: id)
       end
     end

--- a/test/units/report/test_internal.rb
+++ b/test/units/report/test_internal.rb
@@ -20,6 +20,11 @@ class Thinreports::Report::TestInternal < Minitest::Test
     assert_equal internal.default_layout.filename, @layout_file.path
   end
 
+  def test_pathname_layout_specified_in_new_method_should_be_defined_as_default_layout
+    internal = Report::Internal.new(report, layout: Pathname(@layout_file.path))
+    assert_equal internal.default_layout.filename, @layout_file.path
+  end
+
   def test_register_layout_should_be_set_as_default_layout_when_options_are_omitted
     internal = Report::Internal.new(report, {})
     internal.register_layout(@layout_file.path)


### PR DESCRIPTION
Current behavior:
```ruby
path = Pathname.new("foo.tlf")
Thinreports::Report.new(layout: path)

# Thinreports::Report.new(layout: Pathname.new("foo.tlf"))
# NoMethodError: undefined method `=~' for #<Pathname:foo.tlf>
# from /Users/meganemura/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/thinreports-0.10.3/lib/thinreports/layout/base.rb:15:in `load_format'
```

I think supporting Pathname is nice to have since it is widely used like `Rails.root` for example.