### PR TITLE
Add Ruby3 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.4
           - 2.5
           - 2.6
           - 2.7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: Test against ${{ matrix.ruby }}
+    name: Test against ruby ${{ matrix.ruby }} and prawn ${{ matrix.prawn }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -13,7 +13,17 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
+          - 3.0
           - jruby
+        prawn:
+          - 2.2
+          - 2.3
+          - 2.4
+        exclude:
+          - ruby: 3.0
+            prawn: 2.2
+          - ruby: 3.0
+            prawn: 2.3
 
     steps:
     - uses: actions/checkout@v1
@@ -31,9 +41,12 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
 
-    - name: Build and test with Rake
+    - name: Install dependencies
       run: |
         gem install bundler
-        bundle install --jobs 4 --retry 3
+        bundle install --gemfile gemfiles/prawn-${{ matrix.prawn }}.gemfile --jobs 4 --retry 3
+
+    - name: Run tests
+      run: |
         bundle exec rake test:units
         bundle exec rake test:features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
  * Ruby 3.0 support
  * Prawn 2.4 support
+ * Drop Ruby 2.4 support
 
 ## 0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## master
 
+ * Ruby 3.0 support
+ * Prawn 2.4 support
+
 ## 0.11.0
 
 Breaking Changes:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.1
+FROM ruby:3.0.0
 
 RUN apt-get update -qq && apt-get install -y build-essential xvfb
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,3 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'minitest', '>= 5.14.1'
-gem 'mocha', '>= 1.11.2'
-gem 'pdf-inspector', '>= 1.3.0'
-gem 'rake', '>= 13.0.1'

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@
 
 ## Supported versions
 
-  * Ruby 2.4, 2.5, 2.6, 2.7
+  * Ruby 2.4, 2.5, 2.6, 2.7, 3.0
+  * Prawn 2.2, 2.3, 2.4
   * JRuby 9.2
 
 ## Quick Reference

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## Supported versions
 
-  * Ruby 2.4, 2.5, 2.6, 2.7, 3.0
+  * Ruby 2.5, 2.6, 2.7, 3.0
   * Prawn 2.2, 2.3, 2.4
   * JRuby 9.2
 

--- a/gemfiles/prawn-2.2.gemfile
+++ b/gemfiles/prawn-2.2.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'prawn', '~> 2.2.0'
+
+gemspec path: '../'

--- a/gemfiles/prawn-2.3.gemfile
+++ b/gemfiles/prawn-2.3.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'prawn', '~> 2.3.0'
+
+gemspec path: '../'

--- a/gemfiles/prawn-2.4.gemfile
+++ b/gemfiles/prawn-2.4.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'prawn', '~> 2.4.0'
+
+gemspec path: '../'

--- a/lib/thinreports/generator/pdf/prawn_ext/width_of.rb
+++ b/lib/thinreports/generator/pdf/prawn_ext/width_of.rb
@@ -4,22 +4,13 @@ module Thinreports
   module Generator
     module PrawnExt
       module WidthOf
-        # TODO: Remove this path when a version of prawn that includes the following PR is released:
-        # https://github.com/prawnpdf/prawn/pull/1117
+        # This patch fixes the character_spacing effect on text width calculation.
         #
-        # This PR makes this patch unnecessary.
-        #
-        #
-        # Subtract the width of one character space from the string width calculation result.
-        #
-        # The original Prawn::Document#width_of returns the following result:
-        #
-        #  Width of Character is 1
-        #  Width of Character Space is 1
+        # The original #width_of:
         #
         #   width_of('abcd') #=> 4 + 4 = 8
         #
-        # In this width_of, returns the following result:
+        # The #width_of in this patch:
         #
         #   width_of('abcd') #=> 4 + 3 = 7
         #
@@ -32,4 +23,7 @@ module Thinreports
   end
 end
 
-Prawn::Document.prepend Thinreports::Generator::PrawnExt::WidthOf
+# Prawn v2.3 and later includes this patch by https://github.com/prawnpdf/prawn/pull/1117.
+if Prawn::VERSION < '2.3.0'
+  Prawn::Document.prepend Thinreports::Generator::PrawnExt::WidthOf
+end

--- a/test/features/feature_test.rb
+++ b/test/features/feature_test.rb
@@ -45,7 +45,12 @@ class FeatureTest < Minitest::Test
   end
 
   def match_expect_pdf?
-    system("diff-pdf --output-diff=#{path_of('diff.pdf')} #{expect_pdf} #{actual_pdf}")
+    opts = [
+      '--mark-differences',
+      # Allow for small differences that cannot be seen
+      '--channel-tolerance=40'
+    ]
+    system("diff-pdf #{opts.join(' ')} --output-diff=#{path_of('diff.pdf')} #{expect_pdf} #{actual_pdf}")
   end
 
   def actual_pdf

--- a/test/features/image_block/test_feature.rb
+++ b/test/features/image_block/test_feature.rb
@@ -24,7 +24,7 @@ class TestImageBlockFeature < FeatureTest
     )
 
     report.page.item(:overflow).src = image200x100
-    report.page[:thinreports_logo] = open('http://www.thinreports.org/assets/logos/thinreports-logo.png')
+    report.page[:thinreports_logo] = URI.open('http://www.thinreports.org/assets/logos/thinreports-logo.png')
 
     report.page.list(:list) do |list|
       3.times { list.add_row in_list: image50x50 }

--- a/thinreports.gemspec
+++ b/thinreports.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'prawn', '~> 2.2.0'
+  s.add_dependency 'rexml'
 end

--- a/thinreports.gemspec
+++ b/thinreports.gemspec
@@ -21,6 +21,11 @@ Gem::Specification.new do |s|
   end
   s.require_paths = ['lib']
 
-  s.add_dependency 'prawn', '~> 2.2.0'
+  s.add_dependency 'prawn', '~> 2.2'
   s.add_dependency 'rexml'
+
+  s.add_development_dependency 'minitest', '>= 5.14.1'
+  s.add_development_dependency 'mocha', '>= 1.11.2'
+  s.add_development_dependency 'pdf-inspector', '>= 1.3.0'
+  s.add_development_dependency 'rake', '>= 13.0.1'
 end

--- a/thinreports.gemspec
+++ b/thinreports.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://www.thinreports.org'
   s.license     = 'MIT'
 
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.files = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^test/}) }


### PR DESCRIPTION
This PR adds ruby3 and 2.4 support. fixes #108 

It also removes ruby 2.4 support, since it is already EOL and is not supported in prawn 2.3 or later.