### PR TITLE
Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
-## master
+## master (Unreleased)
 
- * Ruby 3.0 support
- * Prawn 2.4 support
- * Drop Ruby 2.4 support
+## 0.12.0
+
+Breaking Changes:
+
+ * Drop Ruby 2.4 support #108, #109
+
+Enhancements:
+
+ * Ruby 3.0 support #108, #109
+ * Prawn 2.4 support #108, #109
 
 ## 0.11.0
 

--- a/lib/thinreports/version.rb
+++ b/lib/thinreports/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Thinreports
-  VERSION = '0.11.0'
+  VERSION = '0.12.0'
 end


### PR DESCRIPTION
## Abstract

This version mainly adds support for Ruby 3.0.

## Testing

- [x] Building a gem is successful
