### PR TITLE
Fix argument of Thinreports::Report.generate in Ruby 3.0

### DIFF
--- a/lib/thinreports/report.rb
+++ b/lib/thinreports/report.rb
@@ -13,8 +13,8 @@ module Thinreports
     end
 
     # @see Thinreports::Report::Base#generate
-    def self.generate(*args, &block)
-      Base.generate(*args, &block)
+    def self.generate(**args, &block)
+      Base.generate(**args, &block)
     end
   end
 end

--- a/test/units/test_report.rb
+++ b/test/units/test_report.rb
@@ -15,4 +15,10 @@ class Thinreports::TestReport < Minitest::Test
   def test_create
     assert_instance_of Report::Base, Report.create {}
   end
+
+  def test_generate_should_raise_when_the_specified_layout_is_not_found
+    assert_raises Thinreports::Errors::LayoutFileNotFound do
+      Report.generate(layout: '') { |_| }
+    end
+  end
 end


### PR DESCRIPTION
## Summary

The sample code raised ArgumentError in Ruby 3.0.

```
Thinreports::Report.generate(filename: 'report.pdf', layout: 'report.tlf') do |report|
  report.start_new_page do |page|
    # :
  end
end
```

This PR changed argument of Thinreports::Report.generate.

## Issue

https://github.com/thinreports/thinreports-generator/issues/115