### PR TITLE
Fix Error::ENOENT on delete temporary file

### DIFF
--- a/lib/thinreports/basic_report/generator/pdf/document/graphics/image.rb
+++ b/lib/thinreports/basic_report/generator/pdf/document/graphics/image.rb
@@ -71,9 +71,8 @@ module Thinreports
           end
 
           def clean_temp_images
-            temp_image_registry.each_value do |image_path|
-              File.delete(image_path) if File.exist?(image_path)
-            end
+            temp_image_registry.each_value(&:close!)
+            temp_image_registry.clear
           end
 
           def temp_image_registry

--- a/test/basic_report/units/generator/pdf/document/graphics/test_image.rb
+++ b/test/basic_report/units/generator/pdf/document/graphics/test_image.rb
@@ -36,6 +36,24 @@ class Thinreports::BasicReport::Generator::PDF::Graphics::TestImage < Minitest::
     assert_equal 6, analyze_pdf_images(@document.render).count
   end
 
+  def test_clean_temp_images
+    @document.base64image(Base64.encode64(read_data_file('image_normal.png')), 0, 0, 100, 100)
+    @document.base64image(Base64.encode64(read_data_file('image_normal.jpg')), 0, 0, 100, 100)
+
+    assert_equal 2, @document.temp_image_registry.size
+
+    image_file_and_paths = @document.temp_image_registry.values.map { |image| [image, image.path] }
+
+    @document.clean_temp_images
+
+    assert_empty @document.temp_image_registry
+
+    image_file_and_paths.each do |file, path|
+      assert_nil file.path
+      refute File.exist?(path)
+    end
+  end
+
   def each_image(&block)
     %w(
       image_normal.png

--- a/test/feature_test.rb
+++ b/test/feature_test.rb
@@ -22,15 +22,7 @@ module Thinreports
     class Base < Minitest::Test
       class << self
         def feature(&block)
-          define_method(:test_feature) do
-            # In CI (GitHub Actions), the following error occurs rarely.
-            #
-            # > Errno::ENOENT: No such file or directory @ apply2files
-            #
-            # Probably GC related. It is not a fundamental solution, but for now,
-            # the problem is reproduced only by CI, so we will deal with it by disabling GC.
-            disable_gc { instance_exec(&block) }
-          end
+          define_method(:test_feature, &block)
         end
       end
 
@@ -66,15 +58,6 @@ module Thinreports
 
       def expect_pdf
         dir.join('expect.pdf')
-      end
-
-      def disable_gc
-        was_disabled = GC.disable
-        begin
-          yield
-        ensure
-          GC.enable unless was_disabled
-        end
       end
     end
   end


### PR DESCRIPTION
In CI (GitHub Actions), the following error occurs rarely.
```
Errno::ENOENT: No such file or directory @ apply2files
```

image file is a Tempfile, so instead of File.delete, close and delete the file by using Tempfile#close!
