### PR TITLE
allow any string to be set to the title of the PDF document metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Breaking Changes:
 Enhancements:
 
 * Add Ruby 3.1, 3.2 support
+* Allow any string to be set to the title attribute of the PDF document metadata
 
 Notes:
 

--- a/lib/thinreports/basic_report/generator/pdf.rb
+++ b/lib/thinreports/basic_report/generator/pdf.rb
@@ -11,11 +11,12 @@ module Thinreports
 
         # @param [Thinreports::BasicReport::Report::Base] report
         # @param [Hash] security (nil)
-        def initialize(report, security: nil)
+        # @param [String] title (nil)
+        def initialize(report, security: nil, title: nil)
           report.finalize
 
           @report = report.internal
-          title = default_layout ? default_layout.format.report_title : nil
+          title ||= default_layout ? default_layout.format.report_title : nil
 
           @document = Document.new(title: title, security: security)
           @drawers = {}

--- a/lib/thinreports/basic_report/report/base.rb
+++ b/lib/thinreports/basic_report/report/base.rb
@@ -149,13 +149,15 @@ module Thinreports
 
         # @param [String] filename
         # @param [Hash] security (see http://prawnpdf.org/api-docs/2.0/Prawn/Document/Security.html#encrypt_document-instance_method)
+        # @param [String] title Value of the title attribute of the PDF document metadata.
+        #   if nil, the title of the default layout file is set.
         # @return [String]
         # @example Generate PDF data
         #   report.generate # => "%PDF-1.4...."
         # @example Create a PDF file
         #   report.generate(filename: 'foo.pdf')
-        def generate(filename: nil, security: nil)
-          Thinreports::BasicReport::Generator::PDF.new(self, security: security).generate(filename)
+        def generate(filename: nil, security: nil, title: nil)
+          Thinreports::BasicReport::Generator::PDF.new(self, security: security, title: title).generate(filename)
         end
 
         # @see Thinreports::BasicReport::Core::Shape::Manager::Target#list

--- a/test/basic_report/units/report/test_base.rb
+++ b/test/basic_report/units/report/test_base.rb
@@ -125,13 +125,20 @@ class Thinreports::BasicReport::Report::TestBase < Minitest::Test
     generator.expects(:generate).with('result.pdf')
 
     Thinreports::BasicReport::Generator::PDF.expects(:new)
-      .with(report, security: { owner_password: 'pass' })
+      .with(report, security: { owner_password: 'pass' }, title: nil)
       .returns(generator)
 
     report.generate(
       filename: 'result.pdf',
       security: { owner_password: 'pass' }
     )
+  end
+
+  def test_generate_when_title_argument_is_specified
+    report = Report::Base.new layout: @layout_file.path
+    pdf = report.generate(title: 'Custom title')
+
+    assert_equal 'Custom title', PDF::Reader.new(StringIO.new(pdf)).info[:Title]
   end
 
   def test_page_should_return_the_current_page


### PR DESCRIPTION
This pull request implements the functionality proposed below the discussion
https://github.com/orgs/thinreports/discussions/37

Usage
```ruby
# foo.tlf has the title "Foo Title".
report = Thinreports::Report.new layout: "foo.tlf"
report.start_new_page

report.generate title: "Custom Title"
```

The metadata title of the PDF document generated above should be set to "Custom Title".