### PR TITLE
allow title argument to be specified in Report.generate method

### DIFF
--- a/lib/thinreports/basic_report/report/base.rb
+++ b/lib/thinreports/basic_report/report/base.rb
@@ -26,12 +26,13 @@ module Thinreports
           # @param layout (see #initialize)
           # @param filename (see #generate)
           # @param security (see #generate)
+          # @param title (see #generate)
           # @param [Hash] report ({}) DEPRECATED. Options for Report.
           # @param [Hash] generator ({}) DEPRECATED. Options for Generator.
           # @yield (see .create)
           # @yieldparam (see .create)
           # @return [String]
-          def generate(layout: nil, filename: nil, security: nil, report: {}, generator: {}, &block)
+          def generate(layout: nil, filename: nil, security: nil, title: nil, report: {}, generator: {}, &block)
             raise ArgumentError, '#generate requires a block' unless block_given?
 
             if report.any? || generator.any?
@@ -44,7 +45,7 @@ module Thinreports
             security ||= generator[:security]
 
             report = create(layout: layout, &block)
-            report.generate(filename: filename, security: security)
+            report.generate(filename: filename, security: security, title: title)
           end
         end
 

--- a/test/basic_report/units/report/test_base.rb
+++ b/test/basic_report/units/report/test_base.rb
@@ -222,7 +222,8 @@ class Thinreports::BasicReport::Report::TestBase < Minitest::Test
     Report::Base.expects(:create).with(layout: '/path/to/layout.tlf').returns(@report)
     @report.expects(:generate).with(
       filename: 'result.pdf',
-      security: { owner_password: 'pass' }
+      security: { owner_password: 'pass' },
+      title: nil
     )
 
     Report::Base.generate(
@@ -238,7 +239,8 @@ class Thinreports::BasicReport::Report::TestBase < Minitest::Test
     Report::Base.expects(:create).with(layout: '/path/to/layout.tlf').returns(@report)
     @report.expects(:generate).with(
       filename: 'result.pdf',
-      security: { owner_password: 'pass' }
+      security: { owner_password: 'pass' },
+      title: nil
     )
 
     Report::Base.generate(
@@ -251,5 +253,11 @@ class Thinreports::BasicReport::Report::TestBase < Minitest::Test
         security: { owner_password: 'deprecated' }
       }
     ) { |_| }
+  end
+
+  def test_Base_generate_when_title_argument_is_specified
+    pdf = Report::Base.generate(layout: @layout_file.path, title: 'Custom title') { start_new_page }
+
+    assert_equal 'Custom title', PDF::Reader.new(StringIO.new(pdf)).info[:Title]
   end
 end


### PR DESCRIPTION
```
Thinreports::Report.generate(layout: '/path/to/layout.tlf', title: 'Custom Title') { start_new_page }
```
This code does not work with the following error.
```
ArgumentError: unknown keyword: :title
```

See https://github.com/orgs/thinreports/discussions/37#discussioncomment-6954604