### PR TITLE
Fix LoadError: cannot load such file -- matrix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem 'rake'
 gem 'minitest'
 gem 'mocha'
 gem 'pdf-inspector'
-gem 'matrix'
 gem 'pdf_matcher-testing'
 
 # suppress warning: assigned but unused variable - y1

--- a/thinreports.gemspec
+++ b/thinreports.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'prawn', '>= 2.4.0'
+  s.add_dependency 'matrix', '~> 0.4'
   s.add_dependency 'rexml'
 end


### PR DESCRIPTION
prawn depends on the matrix gem, which has been bundled since Ruby 3.1. However, a version of prawn that adds the matrix gem dependency has not been released. Therefore, the following error occurs:
```
.../gems/prawn-2.4.0/lib/prawn/transformation_stack.rb:10:in `require': cannot load such file -- matrix (LoadError)
```