### PR TITLE
Add base64 and bigdecimal to the gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## main (Unreleased)
 
+* Add base64 and bigdecimal to the gemspec #133
+
 ## 0.14.1
 
 Enhancements:

--- a/thinreports.gemspec
+++ b/thinreports.gemspec
@@ -26,4 +26,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'matrix', '~> 0.4'
   s.add_dependency 'prawn-disable_word_break', '>= 2.3.1'
   s.add_dependency 'rexml'
+  s.add_dependency 'base64'
+  s.add_dependency 'bigdecimal'
 end


### PR DESCRIPTION
This PR fixes #133 

These gems will no longer be the default gem in the Ruby 3.4.