### PR TITLE
Support for Minitest v6.0

### DIFF
--- a/test/basic_report/test_helper.rb
+++ b/test/basic_report/test_helper.rb
@@ -2,7 +2,6 @@
 
 require 'minitest/autorun'
 require 'minitest/spec'
-require 'minitest/unit'
 require 'mocha/minitest'
 require 'pdf/inspector'
 

--- a/test/main/test_helper.rb
+++ b/test/main/test_helper.rb
@@ -2,6 +2,5 @@
 
 require 'minitest/autorun'
 require 'minitest/spec'
-require 'minitest/unit'
 
 require 'thinreports'

--- a/test/section_report/test_helper.rb
+++ b/test/section_report/test_helper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'minitest/autorun'
-require 'minitest/unit'
 require 'mocha/minitest'
 
 require 'thinreports'


### PR DESCRIPTION
Since ‘minitest/unit’ was removed in minitest 6.0, tests will currently fail in environments where minitest 6.0 is installed.

In Ruby 3.0/3.1, tests must be run using minitest 5.x, but
even in minitest 5.x, the tests will succeed without `require ‘minitest/unit’`.

Therefore, `require ‘minitest/unit’` is not required for tests in the currently supported Ruby runtime environments.